### PR TITLE
chore: remove time-master from o2

### DIFF
--- a/scripts/o2/config.ts
+++ b/scripts/o2/config.ts
@@ -26,10 +26,11 @@ export const innerExtensions4pack = [
     packageName: 'iceworks-team.iceworks-style-helper',
     assetsFolders: ['assets', 'schemas'],
   },
-  {
-    packageName: 'iceworks-team.iceworks-time-master',
-    assetsFolders: ['assets', 'schemas'],
-  },
+  // time-master maybe has performance problem in O2
+  // {
+  //   packageName: 'iceworks-team.iceworks-time-master',
+  //   assetsFolders: ['assets', 'schemas'],
+  // },
   {
     packageName: 'iceworks-team.iceworks-refactor',
     assetsFolders: ['assets', 'schemas'],


### PR DESCRIPTION
time-master 在 O2 客户端下有性能问题并可能导致机器卡死，暂时先下架。后续需要排查具体问题