### PR TITLE
chore: remove typescript dependency

### DIFF
--- a/packages/doctor/CHANGELOG.md
+++ b/packages/doctor/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+## 0.4.2
+
+- chore: remove typescript dependency and use the local typescript
+
 ## 0.4.1
 
 - feat: support stylelint

--- a/packages/doctor/package.json
+++ b/packages/doctor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@appworks/doctor",
   "description": "Analyse and running codemods over react/rax projects, troubleshooting and automatically fixing errors",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "keywords": [
     "doctor",
     "analysis",
@@ -39,7 +39,6 @@
     "ignore": "^5.1.8",
     "jscpd": "^3.3.3",
     "moment": "^2.29.1",
-    "stylelint": "^14.5.1",
-    "typescript": "^3.0.0"
+    "stylelint": "^14.5.1"
   }
 }


### PR DESCRIPTION
@appworks/doctor 移除 ts 的依赖，使用本地的 ts 的版本进行 typescript-eslint 的检查和修复