### PR TITLE
Add 2 digits after unit abbreviation for numeric values

### DIFF
--- a/extensions/time-master/src/views/timerProvider.ts
+++ b/extensions/time-master/src/views/timerProvider.ts
@@ -22,7 +22,7 @@ import logger from '../utils/logger';
 import { recordDAU } from '@appworks/recorder';
 import recorder from '../utils/recorder';
 
-const NUMBER_FORMAT = '0 a';
+const NUMBER_FORMAT = '0.[00] a';
 const timerCollapsedStateMap: {[key: string]: TreeItemCollapsibleState} = {};
 
 class TimerItem {


### PR DESCRIPTION
Make number abbreviations more precise with 2 decimal digits after unit abbreviation like 1.23 k instead of 1 k